### PR TITLE
Handle http 200 responses with invalid content with warning.

### DIFF
--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/exception/WebSubAdapterException.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/exception/WebSubAdapterException.java
@@ -47,4 +47,13 @@ public class WebSubAdapterException extends Exception {
         this.errorCode = errorCode;
     }
 
+    public String getErrorCode() {
+
+        return errorCode;
+    }
+
+    public String getDescription() {
+
+        return description;
+    }
 }

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
@@ -250,8 +250,13 @@ public class WebSubHubAdapterUtil {
                                 log.debug("Success WebSub Hub operation: " + operation + ", topic: " + topic);
                             }
                         } else {
-                            throw handleServerException(ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB, null, topic, operation,
-                                    responseString);
+                            // Since the endpoint respond with http status code 200, adapter accepts the response as a
+                            // success and log it as a warning. In current implementation this only happens
+                            // 1. if the topic exists when registering the topic.
+                            // 2. if the topic doesn't exist when de-registering the topic
+                            // TODO: This will have to be updated when the websub hub error responses are updated.
+                            log.warn(String.format(ERROR_INVALID_RESPONSE_FROM_WEBSUB_HUB.getDescription(),
+                                    topic, operation, responseString));
                         }
                     } else {
                         throw handleServerException(ERROR_NO_RESPONSE_FROM_WEBSUB_HUB, null, topic, operation);

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/test/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtilTest.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/test/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtilTest.java
@@ -220,8 +220,7 @@ public class WebSubHubAdapterUtilTest {
                         WebSubAdapterServerException.class},
                 {TEST_TOPIC, WEBSUB_HUB_BASE_URL, TEST_OPERATION, ResponseStatus.NULL_ENTITY,
                         WebSubAdapterServerException.class},
-                {TEST_TOPIC, WEBSUB_HUB_BASE_URL, TEST_OPERATION, ResponseStatus.NON_SUCCESS_OPERATION,
-                        WebSubAdapterServerException.class},
+                {TEST_TOPIC, WEBSUB_HUB_BASE_URL, TEST_OPERATION, ResponseStatus.NON_SUCCESS_OPERATION, null},
         };
     }
 


### PR DESCRIPTION
## Purpose
> WebSub Hub returns 200 when the topic exists / not exists cases, with `hub.mode=denied` response. In this PR, adapter will accept 200 responses with content and if the content doesn't have `hub.mode=success`, adapter will log a `WARN` message and consider the API call is a success.