### PR TITLE
Improve outbound-adapter With Suggested Changes

### DIFF
--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/config/WebSubAdapterConfiguration.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/config/WebSubAdapterConfiguration.java
@@ -36,12 +36,13 @@ public class WebSubAdapterConfiguration {
     private static final String HTTP_READ_TIMEOUT = "adapter.websubhub.httpReadTimeout";
     private static final String HTTP_CONNECTION_REQUEST_TIMEOUT = "adapter.websubhub.httpConnectionRequestTimeout";
     private static final String DEFAULT_MAX_CONNECTIONS = "adapter.websubhub.defaultMaxConnections";
-
+    private static final String DEFAULT_MAX_CONNECTIONS_PER_ROUTE = "adapter.websubhub.defaultMaxConnectionsPerRoute";
     private final boolean adapterEnabled;
     private final int httpConnectionTimeout;
     private final int httpReadTimeout;
     private final int httpConnectionRequestTimeout;
     private final int defaultMaxConnections;
+    private final int defaultMaxConnectionsPerRoute;
 
     private String webSubHubBaseUrl;
 
@@ -74,6 +75,9 @@ public class WebSubAdapterConfiguration {
         this.defaultMaxConnections =
                 configurationProvider.getProperty(DEFAULT_MAX_CONNECTIONS).map(Integer::parseInt)
                         .orElse(WebSubHubAdapterConstants.DEFAULT_HTTP_MAX_CONNECTIONS);
+        this.defaultMaxConnectionsPerRoute =
+                configurationProvider.getProperty(DEFAULT_MAX_CONNECTIONS_PER_ROUTE).map(Integer::parseInt)
+                        .orElse(WebSubHubAdapterConstants.DEFAULT_HTTP_MAX_CONNECTIONS_PER_ROUTE);
     }
 
     /**

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/config/WebSubAdapterConfiguration.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/config/WebSubAdapterConfiguration.java
@@ -20,6 +20,7 @@ package org.wso2.identity.outbound.adapter.websubhub.config;
 
 import org.wso2.identity.outbound.adapter.common.OutboundAdapterConfigurationProvider;
 import org.wso2.identity.outbound.adapter.websubhub.exception.WebSubAdapterException;
+import org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants;
 
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.WEB_SUB_BASE_URL_NOT_CONFIGURED;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterUtil.handleClientException;
@@ -31,8 +32,16 @@ public class WebSubAdapterConfiguration {
 
     private static final String ADAPTER_ENABLED_CONFIG = "adapter.websubhub.enabled";
     private static final String ADAPTER_HUB_URL_CONFIG = "adapter.websubhub.baseUrl";
+    private static final String HTTP_CONNECTION_TIMEOUT = "adapter.websubhub.httpConnectionTimeout";
+    private static final String  HTTP_READ_TIMEOUT = "adapter.websubhub.httpReadTimeout";
+    private static final String HTTP_CONNECTION_REQUEST_TIMEOUT = "adapter.websubhub.httpConnectionRequestTimeout";
+    private static final String DEFAULT_MAX_CONNECTIONS = "adapter.websubhub.defaultMaxConnections";
 
     private final boolean adapterEnabled;
+    private final int httpConnectionTimeout;
+    private final int httpReadTimeout;
+    private final int httpConnectionRequestTimeout;
+    private final int defaultMaxConnections;
 
     private String webSubHubBaseUrl;
 
@@ -52,6 +61,19 @@ public class WebSubAdapterConfiguration {
             this.webSubHubBaseUrl = configurationProvider.getProperty(ADAPTER_HUB_URL_CONFIG)
                     .orElseThrow(() -> handleClientException(WEB_SUB_BASE_URL_NOT_CONFIGURED));
         }
+
+        this.httpConnectionTimeout =
+                configurationProvider.getProperty(HTTP_CONNECTION_TIMEOUT).map(Integer::parseInt).orElse(
+                        WebSubHubAdapterConstants.DEFAULT_HTTP_CONNECTION_TIMEOUT);
+        this.httpReadTimeout =
+                configurationProvider.getProperty(HTTP_READ_TIMEOUT).map(Integer::parseInt)
+                        .orElse(WebSubHubAdapterConstants.DEFAULT_HTTP_READ_TIMEOUT);
+        this.httpConnectionRequestTimeout =
+                configurationProvider.getProperty(HTTP_CONNECTION_REQUEST_TIMEOUT).map(Integer::parseInt)
+                        .orElse(WebSubHubAdapterConstants.DEFAULT_HTTP_CONNECTION_REQUEST_TIMEOUT);
+        this.defaultMaxConnections =
+                configurationProvider.getProperty(DEFAULT_MAX_CONNECTIONS).map(Integer::parseInt)
+                        .orElse(WebSubHubAdapterConstants.DEFAULT_HTTP_MAX_CONNECTIONS);
     }
 
     /**
@@ -72,5 +94,45 @@ public class WebSubAdapterConfiguration {
     public String getWebSubHubBaseUrl() {
 
         return webSubHubBaseUrl;
+    }
+
+    /**
+     * Returns the HTTP connection timeout.
+     *
+     * @return HTTP connection timeout.
+     */
+    public Integer getHTTPConnectionTimeout() {
+
+        return httpConnectionTimeout;
+    }
+
+    /**
+     * Returns the HTTP read timeout.
+     *
+     * @return HTTP Read Timeout.
+     */
+    public Integer getHttpReadTimeout() {
+
+        return httpReadTimeout;
+    }
+
+    /**
+     * Returns the http connection request timeout.
+     *
+     * @return http connection request timeout.
+     */
+    public Integer getHttpConnectionRequestTimeout() {
+
+        return httpConnectionRequestTimeout;
+    }
+
+    /**
+     * Returns the default max connections.
+     *
+     * @return default max connections.
+     */
+    public Integer getDefaultMaxConnections() {
+
+        return defaultMaxConnections;
     }
 }

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/config/WebSubAdapterConfiguration.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/config/WebSubAdapterConfiguration.java
@@ -33,7 +33,7 @@ public class WebSubAdapterConfiguration {
     private static final String ADAPTER_ENABLED_CONFIG = "adapter.websubhub.enabled";
     private static final String ADAPTER_HUB_URL_CONFIG = "adapter.websubhub.baseUrl";
     private static final String HTTP_CONNECTION_TIMEOUT = "adapter.websubhub.httpConnectionTimeout";
-    private static final String  HTTP_READ_TIMEOUT = "adapter.websubhub.httpReadTimeout";
+    private static final String HTTP_READ_TIMEOUT = "adapter.websubhub.httpReadTimeout";
     private static final String HTTP_CONNECTION_REQUEST_TIMEOUT = "adapter.websubhub.httpConnectionRequestTimeout";
     private static final String DEFAULT_MAX_CONNECTIONS = "adapter.websubhub.defaultMaxConnections";
 

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/config/WebSubAdapterConfiguration.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/config/WebSubAdapterConfiguration.java
@@ -139,4 +139,14 @@ public class WebSubAdapterConfiguration {
 
         return defaultMaxConnections;
     }
+
+    /**
+     * Returns the default max connections per route.
+     *
+     * @return default max connections per route.
+     */
+    public int getDefaultMaxConnectionsPerRoute() {
+
+        return defaultMaxConnectionsPerRoute;
+    }
 }

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/config/WebSubAdapterConfiguration.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/config/WebSubAdapterConfiguration.java
@@ -101,7 +101,7 @@ public class WebSubAdapterConfiguration {
      *
      * @return HTTP connection timeout.
      */
-    public Integer getHTTPConnectionTimeout() {
+    public int getHTTPConnectionTimeout() {
 
         return httpConnectionTimeout;
     }
@@ -111,7 +111,7 @@ public class WebSubAdapterConfiguration {
      *
      * @return HTTP Read Timeout.
      */
-    public Integer getHttpReadTimeout() {
+    public int getHttpReadTimeout() {
 
         return httpReadTimeout;
     }
@@ -121,7 +121,7 @@ public class WebSubAdapterConfiguration {
      *
      * @return http connection request timeout.
      */
-    public Integer getHttpConnectionRequestTimeout() {
+    public int getHttpConnectionRequestTimeout() {
 
         return httpConnectionRequestTimeout;
     }
@@ -131,7 +131,7 @@ public class WebSubAdapterConfiguration {
      *
      * @return default max connections.
      */
-    public Integer getDefaultMaxConnections() {
+    public int getDefaultMaxConnections() {
 
         return defaultMaxConnections;
     }

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/internal/ClientManager.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/internal/ClientManager.java
@@ -108,7 +108,7 @@ public class ClientManager {
         int maxConnections = WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration()
                 .getDefaultMaxConnections();
         int maxConnectionsPerRoute = WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration()
-                .getDefaultMaxConnections();
+                .getDefaultMaxConnectionsPerRoute();
 
         ConnectingIOReactor ioReactor = new DefaultConnectingIOReactor();
         PoolingNHttpClientConnectionManager poolingHttpClientConnectionMgr = new

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/internal/ClientManager.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/internal/ClientManager.java
@@ -18,7 +18,6 @@
 
 package org.wso2.identity.outbound.adapter.websubhub.internal;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.client.config.RequestConfig;
@@ -30,7 +29,6 @@ import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
 import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
 import org.apache.http.nio.reactor.ConnectingIOReactor;
 import org.apache.http.ssl.SSLContexts;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.identity.outbound.adapter.websubhub.exception.WebSubAdapterException;
 
 import java.io.IOException;
@@ -41,8 +39,6 @@ import java.security.NoSuchAlgorithmException;
 import javax.net.ssl.SSLContext;
 
 import static java.util.Objects.isNull;
-import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.CONNECTION_POOL_MAX_CONNECTIONS;
-import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.CONNECTION_POOL_MAX_CONNECTIONS_PER_ROUTE;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.ERROR_CREATING_ASYNC_HTTP_CLIENT;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.ERROR_CREATING_SSL_CONTEXT;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.ERROR_GETTING_ASYNC_CLIENT;

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/internal/ClientManager.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/internal/ClientManager.java
@@ -114,26 +114,6 @@ public class ClientManager {
         int maxConnectionsPerRoute = WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration()
                 .getDefaultMaxConnections();
 
-        if (StringUtils.isNotEmpty(maxConnectionsString)) {
-            try {
-                maxConnections = Integer.parseInt(maxConnectionsString);
-            } catch (NumberFormatException e) {
-                // Default value is used.
-                LOG.error("Error while converting MaxConnection " + maxConnections + " to integer. So proceed with " +
-                        "default value ", e);
-            }
-        }
-
-        if (StringUtils.isNotEmpty(maxConnectionsPerRouteString)) {
-            try {
-                maxConnectionsPerRoute = Integer.parseInt(maxConnectionsPerRouteString);
-            } catch (NumberFormatException e) {
-                // Default value is used.
-                LOG.error("Error while converting MaxConnectionsPerRoute " + maxConnectionsPerRoute + " to integer. " +
-                        "So proceed with default value ", e);
-            }
-        }
-
         ConnectingIOReactor ioReactor = new DefaultConnectingIOReactor();
         PoolingNHttpClientConnectionManager poolingHttpClientConnectionMgr = new
                 PoolingNHttpClientConnectionManager(ioReactor);

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/internal/ClientManager.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/internal/ClientManager.java
@@ -109,8 +109,6 @@ public class ClientManager {
 
     private PoolingNHttpClientConnectionManager createPoolingConnectionManager() throws IOException {
 
-        String maxConnectionsString = IdentityUtil.getProperty(CONNECTION_POOL_MAX_CONNECTIONS);
-        String maxConnectionsPerRouteString = IdentityUtil.getProperty(CONNECTION_POOL_MAX_CONNECTIONS_PER_ROUTE);
         int maxConnections = WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration()
                 .getDefaultMaxConnections();
         int maxConnectionsPerRoute = WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration()

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/internal/ClientManager.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/internal/ClientManager.java
@@ -54,10 +54,6 @@ import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapter
 public class ClientManager {
 
     private static final Log LOG = LogFactory.getLog(ClientManager.class);
-    private static final int HTTP_CONNECTION_TIMEOUT = 300;
-    private static final int HTTP_READ_TIMEOUT = 300;
-    private static final int HTTP_CONNECTION_REQUEST_TIMEOUT = 300;
-    private static final int DEFAULT_MAX_CONNECTIONS = 20;
     private final CloseableHttpAsyncClient httpAsyncClient;
 
     /**
@@ -100,9 +96,12 @@ public class ClientManager {
     private RequestConfig createRequestConfig() {
 
         return RequestConfig.custom()
-                .setConnectTimeout(HTTP_CONNECTION_TIMEOUT)
-                .setConnectionRequestTimeout(HTTP_CONNECTION_REQUEST_TIMEOUT)
-                .setSocketTimeout(HTTP_READ_TIMEOUT)
+                .setConnectTimeout(WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration()
+                        .getHTTPConnectionTimeout())
+                .setConnectionRequestTimeout(WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration()
+                        .getHttpConnectionRequestTimeout())
+                .setSocketTimeout(
+                        WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration().getHttpReadTimeout())
                 .setRedirectsEnabled(false)
                 .setRelativeRedirectsAllowed(false)
                 .build();
@@ -112,8 +111,10 @@ public class ClientManager {
 
         String maxConnectionsString = IdentityUtil.getProperty(CONNECTION_POOL_MAX_CONNECTIONS);
         String maxConnectionsPerRouteString = IdentityUtil.getProperty(CONNECTION_POOL_MAX_CONNECTIONS_PER_ROUTE);
-        int maxConnections = DEFAULT_MAX_CONNECTIONS;
-        int maxConnectionsPerRoute = DEFAULT_MAX_CONNECTIONS;
+        int maxConnections = WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration()
+                .getDefaultMaxConnections();
+        int maxConnectionsPerRoute = WebSubHubAdapterDataHolder.getInstance().getAdapterConfiguration()
+                .getDefaultMaxConnections();
 
         if (StringUtils.isNotEmpty(maxConnectionsString)) {
             try {

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/internal/WebSubHubAdapterServiceComponent.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/internal/WebSubHubAdapterServiceComponent.java
@@ -46,9 +46,9 @@ public class WebSubHubAdapterServiceComponent {
             WebSubHubAdapterServiceImpl webSubHubEventAdapter = new WebSubHubAdapterServiceImpl();
             context.getBundleContext().registerService(WebSubHubAdapterService.class.getName(),
                     webSubHubEventAdapter, null);
-            WebSubHubAdapterDataHolder.getInstance().setClientManager(new ClientManager());
             WebSubHubAdapterDataHolder.getInstance().setAdapterConfiguration(new WebSubAdapterConfiguration(
                     OutboundAdapterConfigurationProvider.getInstance()));
+            WebSubHubAdapterDataHolder.getInstance().setClientManager(new ClientManager());
             if (log.isDebugEnabled()) {
                 log.debug("Successfully activated the WebSub Hub adapter service.");
             }

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/service/WebSubHubAdapterServiceImpl.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/service/WebSubHubAdapterServiceImpl.java
@@ -62,7 +62,7 @@ public class WebSubHubAdapterServiceImpl implements WebSubHubAdapterService {
                     getWebSubBaseURL());
         } else {
             log.warn("Event cannot be published, WebSub Hub Adapter is not enabled.");
-            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED);
+            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED, "event publishing");
         }
     }
 
@@ -77,7 +77,7 @@ public class WebSubHubAdapterServiceImpl implements WebSubHubAdapterService {
             }
         } else {
             log.warn("WebSub Hub Topic cannot be registered, WebSub Hub Adapter is not enabled.");
-            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED);
+            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED, "topic registration");
         }
     }
 
@@ -92,7 +92,7 @@ public class WebSubHubAdapterServiceImpl implements WebSubHubAdapterService {
             }
         } else {
             log.warn("WebSub Hub Topic cannot be de-registered, WebSub Hub Adapter is not enabled.");
-            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED);
+            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED, "topic registration");
         }
     }
 

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/service/WebSubHubAdapterServiceImpl.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/service/WebSubHubAdapterServiceImpl.java
@@ -62,7 +62,7 @@ public class WebSubHubAdapterServiceImpl implements WebSubHubAdapterService {
                     getWebSubBaseURL());
         } else {
             log.warn("Event cannot be published, WebSub Hub Adapter is not enabled.");
-            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED, "event publishing");
+            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED);
         }
     }
 
@@ -77,7 +77,7 @@ public class WebSubHubAdapterServiceImpl implements WebSubHubAdapterService {
             }
         } else {
             log.warn("WebSub Hub Topic cannot be registered, WebSub Hub Adapter is not enabled.");
-            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED, "topic registration");
+            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED);
         }
     }
 
@@ -92,7 +92,7 @@ public class WebSubHubAdapterServiceImpl implements WebSubHubAdapterService {
             }
         } else {
             log.warn("WebSub Hub Topic cannot be de-registered, WebSub Hub Adapter is not enabled.");
-            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED, "topic registration");
+            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED);
         }
     }
 

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/service/WebSubHubAdapterServiceImpl.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/service/WebSubHubAdapterServiceImpl.java
@@ -33,6 +33,7 @@ import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapter
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.ERROR_DEREGISTERING_HUB_TOPIC;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.ERROR_REGISTERING_HUB_TOPIC;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.WEB_SUB_BASE_URL_NOT_CONFIGURED;
+import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.WEB_SUB_HUB_ADAPTER_DISABLED;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.REGISTER;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.TOPIC_SEPARATOR;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterUtil.buildSecurityEventToken;
@@ -61,6 +62,7 @@ public class WebSubHubAdapterServiceImpl implements WebSubHubAdapterService {
                     getWebSubBaseURL());
         } else {
             log.warn("Event cannot be published, WebSub Hub Adapter is not enabled.");
+            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED);
         }
     }
 
@@ -75,6 +77,7 @@ public class WebSubHubAdapterServiceImpl implements WebSubHubAdapterService {
             }
         } else {
             log.warn("WebSub Hub Topic cannot be registered, WebSub Hub Adapter is not enabled.");
+            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED);
         }
     }
 
@@ -89,6 +92,7 @@ public class WebSubHubAdapterServiceImpl implements WebSubHubAdapterService {
             }
         } else {
             log.warn("WebSub Hub Topic cannot be de-registered, WebSub Hub Adapter is not enabled.");
+            throw handleClientException(WEB_SUB_HUB_ADAPTER_DISABLED);
         }
     }
 

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
@@ -69,7 +69,8 @@ public class WebSubHubAdapterConstants {
         ERROR_INVALID_WEB_SUB_OPERATION("60009", "Invalid WebSub operation input", "WebSub operation cannot be null " +
                 "or empty."),
         WEB_SUB_HUB_ADAPTER_DISABLED("60010", "WebSub Hub adapter is disabled.",
-                "WebSub Hub adapter is disabled."),
+                "Error in %s. WebSub Hub adapter is disabled."),
+
         //server errors.
         ERROR_REGISTERING_HUB_TOPIC("65001", "Error registering WebSub Hub topic.",
                 "Server error encountered while registering the WebSub Hub topic: %s, tenant: %s."),

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
@@ -37,7 +37,10 @@ public class WebSubHubAdapterConstants {
     public static final String CORRELATION_ID_REQUEST_HEADER = "activityid";
     public static final String CONNECTION_POOL_MAX_CONNECTIONS = "AdaptiveAuth.MaxTotalConnections";
     public static final String CONNECTION_POOL_MAX_CONNECTIONS_PER_ROUTE = "AdaptiveAuth.MaxTotalConnectionsPerRoute";
-
+    public static final Integer DEFAULT_HTTP_CONNECTION_TIMEOUT = 300;
+    public static final Integer DEFAULT_HTTP_READ_TIMEOUT = 300;
+    public static final Integer DEFAULT_HTTP_CONNECTION_REQUEST_TIMEOUT = 300;
+    public static final Integer DEFAULT_HTTP_MAX_CONNECTIONS = 20;
     private static final String WEB_SUB_ADAPTER_ERROR_CODE_PREFIX = "WEBSUB-";
 
     private WebSubHubAdapterConstants() {

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
@@ -68,7 +68,8 @@ public class WebSubHubAdapterConstants {
                 "be null or empty."),
         ERROR_INVALID_WEB_SUB_OPERATION("60009", "Invalid WebSub operation input", "WebSub operation cannot be null " +
                 "or empty."),
-
+        WEB_SUB_HUB_ADAPTER_DISABLED("60010", "WebSub Hub adapter is disabled.",
+                "WebSub Hub adapter is disabled."),
         //server errors.
         ERROR_REGISTERING_HUB_TOPIC("65001", "Error registering WebSub Hub topic.",
                 "Server error encountered while registering the WebSub Hub topic: %s, tenant: %s."),

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
@@ -35,8 +35,6 @@ public class WebSubHubAdapterConstants {
     public static final String ACCEPTED = "accepted";
     public static final String RESPONSE_FOR_SUCCESSFUL_OPERATION = HUB_MODE + "=" + ACCEPTED;
     public static final String CORRELATION_ID_REQUEST_HEADER = "activityid";
-    public static final String CONNECTION_POOL_MAX_CONNECTIONS = "AdaptiveAuth.MaxTotalConnections";
-    public static final String CONNECTION_POOL_MAX_CONNECTIONS_PER_ROUTE = "AdaptiveAuth.MaxTotalConnectionsPerRoute";
     public static final Integer DEFAULT_HTTP_CONNECTION_TIMEOUT = 300;
     public static final Integer DEFAULT_HTTP_READ_TIMEOUT = 300;
     public static final Integer DEFAULT_HTTP_CONNECTION_REQUEST_TIMEOUT = 300;
@@ -115,5 +113,4 @@ public class WebSubHubAdapterConstants {
             return description;
         }
     }
-
 }

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
@@ -67,7 +67,7 @@ public class WebSubHubAdapterConstants {
         ERROR_INVALID_WEB_SUB_OPERATION("60009", "Invalid WebSub operation input", "WebSub operation cannot be null " +
                 "or empty."),
         WEB_SUB_HUB_ADAPTER_DISABLED("60010", "WebSub Hub adapter is disabled.",
-                "Error in %s. WebSub Hub adapter is disabled."),
+                "WebSub Hub adapter is disabled."),
 
         //server errors.
         ERROR_REGISTERING_HUB_TOPIC("65001", "Error registering WebSub Hub topic.",

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
@@ -39,6 +39,7 @@ public class WebSubHubAdapterConstants {
     public static final Integer DEFAULT_HTTP_READ_TIMEOUT = 300;
     public static final Integer DEFAULT_HTTP_CONNECTION_REQUEST_TIMEOUT = 300;
     public static final Integer DEFAULT_HTTP_MAX_CONNECTIONS = 20;
+    public static final Integer DEFAULT_HTTP_MAX_CONNECTIONS_PER_ROUTE = 20;
     private static final String WEB_SUB_ADAPTER_ERROR_CODE_PREFIX = "WEBSUB-";
 
     private WebSubHubAdapterConstants() {

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
@@ -46,6 +46,7 @@ import org.wso2.identity.outbound.adapter.websubhub.exception.WebSubAdapterServe
 import org.wso2.identity.outbound.adapter.websubhub.internal.WebSubHubAdapterDataHolder;
 import org.wso2.identity.outbound.adapter.websubhub.model.EventPayload;
 import org.wso2.identity.outbound.adapter.websubhub.model.SecurityEventTokenPayload;
+import org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubCorrelationLogUtils.RequestStatus;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -172,14 +173,20 @@ public class WebSubHubAdapterUtil {
             log.debug("Publishing event data to WebSubHub. URL: " + url + " tenant domain: " + tenantDomain);
         }
 
+        WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(request);
+        long requestStartTime = System.currentTimeMillis();
         client.execute(request, new FutureCallback<HttpResponse>() {
             @Override
             public void completed(final HttpResponse response) {
 
                 int responseCode = response.getStatusLine().getStatusCode();
+                String responsePhrase = response.getStatusLine().getReasonPhrase();
                 if (log.isDebugEnabled()) {
                     log.debug("WebSubHub request completed. Response code: " + responseCode);
                 }
+                WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(request, requestStartTime,
+                        RequestStatus.COMPLETED.getStatus(), String.valueOf(responseCode), responsePhrase);
+
                 if (responseCode == 200 || responseCode == 201 || responseCode == 202 || responseCode == 204) {
                     // Check for 200 success code range.
                     if (log.isDebugEnabled()) {
@@ -209,13 +216,15 @@ public class WebSubHubAdapterUtil {
 
             @Override
             public void failed(final Exception ex) {
-
+                WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(request, requestStartTime,
+                        RequestStatus.FAILED.getStatus(), ex.getMessage());
                 log.error("Publishing event data to WebSubHub failed. ", ex);
             }
 
             @Override
             public void cancelled() {
-
+                WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(request, requestStartTime,
+                        RequestStatus.CANCELLED.getStatus());
                 log.error("Publishing event data to WebSubHub cancelled.");
             }
         });

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
@@ -216,6 +216,7 @@ public class WebSubHubAdapterUtil {
 
             @Override
             public void failed(final Exception ex) {
+
                 WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(request, requestStartTime,
                         RequestStatus.FAILED.getStatus(), ex.getMessage());
                 log.error("Publishing event data to WebSubHub failed. ", ex);
@@ -223,6 +224,7 @@ public class WebSubHubAdapterUtil {
 
             @Override
             public void cancelled() {
+
                 WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(request, requestStartTime,
                         RequestStatus.CANCELLED.getStatus());
                 log.error("Publishing event data to WebSubHub cancelled.");

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
@@ -174,7 +174,7 @@ public class WebSubHubAdapterUtil {
         }
 
         WebSubHubCorrelationLogUtils.triggerCorrelationLogForRequest(request);
-        long requestStartTime = System.currentTimeMillis();
+        final long requestStartTime = System.currentTimeMillis();
         client.execute(request, new FutureCallback<HttpResponse>() {
             @Override
             public void completed(final HttpResponse response) {

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubCorrelationLogUtils.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubCorrelationLogUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubCorrelationLogUtils.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubCorrelationLogUtils.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * This software is the property of WSO2 LLC. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package org.wso2.identity.outbound.adapter.websubhub.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This class contains the utility methods for adding correlation logs for websubhub publisher.
+ * TODO: Replace this logger implementation with a generalized logger utility class in the carbon-kernel.
+ */
+public class WebSubHubCorrelationLogUtils {
+
+    private static final Log correlationLog = LogFactory.getLog("correlation");
+    private static final String CORRELATION_LOG_SYSTEM_PROPERTY = "enableCorrelationLogs";
+    private static final String CORRELATION_LOG_REQUEST_START = "HTTP-Out-Request";
+    private static final String CORRELATION_LOG_REQUEST_END = "HTTP-Out-Response";
+    private static final String CORRELATION_LOG_SEPARATOR = "|";
+    private static Boolean isEnableCorrelationLogs;
+
+    /**
+     * Trigger correlation logs for http out request.
+     *
+     * @param request   Http out request.
+     */
+    public static void triggerCorrelationLogForRequest(HttpEntityEnclosingRequestBase request) {
+
+        if (isCorrelationLogsEnabled() && correlationLog.isInfoEnabled()) {
+            List<String> logPropertiesList = new ArrayList<>();
+            logPropertiesList.add(CORRELATION_LOG_REQUEST_START);
+            logPropertiesList.add(Long.toString(System.currentTimeMillis()));
+            logPropertiesList.add(request.getMethod());
+            logPropertiesList.add(request.getURI().getQuery());
+            logPropertiesList.add(request.getURI().getPath());
+
+            correlationLog.info(createFormattedLog(logPropertiesList));
+        }
+    }
+
+    /**
+     * Trigger correlation logs for http out response.
+     *
+     * @param request           Http out request.
+     * @param requestStartTime  Request start time.
+     * @param otherParams       Other response parameters that needs to be logged.
+     */
+    public static void triggerCorrelationLogForResponse(HttpEntityEnclosingRequestBase request, long requestStartTime,
+                                                        String... otherParams) {
+
+        if (isCorrelationLogsEnabled() && correlationLog.isInfoEnabled()) {
+            long currentTime = System.currentTimeMillis();
+            long timeTaken = currentTime - requestStartTime;
+
+            List<String> logPropertiesList = new ArrayList<>();
+            logPropertiesList.add(Long.toString(timeTaken));
+            logPropertiesList.add(CORRELATION_LOG_REQUEST_END);
+            logPropertiesList.add(Long.toString(requestStartTime));
+            logPropertiesList.add(request.getMethod());
+            logPropertiesList.add(request.getURI().getQuery());
+            logPropertiesList.add(request.getURI().getPath());
+            Collections.addAll(logPropertiesList, otherParams);
+
+            correlationLog.info(createFormattedLog(logPropertiesList));
+        }
+    }
+
+    /**
+     * Is correlation logs enabled in the system.
+     *
+     * @return Boolean indicating correlation logs enabled or not.
+     */
+    private static boolean isCorrelationLogsEnabled() {
+
+        if (isEnableCorrelationLogs == null) {
+            isEnableCorrelationLogs = Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY));
+        }
+        return isEnableCorrelationLogs;
+    }
+
+    /**
+     * Create the log line that should be printed.
+     *
+     * @param logPropertiesList List of log values that should be printed in the log.
+     * @return The log line.
+     */
+    private static String createFormattedLog(List<String> logPropertiesList) {
+
+        StringBuilder sb = new StringBuilder();
+        int count = 0;
+        for (String property: logPropertiesList) {
+            sb.append(property);
+            if (count < logPropertiesList.size() - 1) {
+                sb.append(CORRELATION_LOG_SEPARATOR);
+            }
+            count++;
+        }
+        return sb.toString();
+    }
+
+    /**
+     * WebSubHub outgoing request status.
+     */
+    public enum RequestStatus {
+
+        COMPLETED("completed"),
+        FAILED("failed"),
+        CANCELLED("cancelled");
+
+        private final String status;
+
+        RequestStatus(String status) {
+
+            this.status = status;
+        }
+
+        public String getStatus() {
+
+            return status;
+        }
+    }
+}

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubCorrelationLogUtils.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubCorrelationLogUtils.java
@@ -1,10 +1,19 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
- * This software is the property of WSO2 LLC. and its suppliers, if any.
- * Dissemination of any information or reproduction of any material contained
- * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
- * You may not alter or remove any copyright or other notice from copies of this content.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.identity.outbound.adapter.websubhub.util;

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubCorrelationLogUtils.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubCorrelationLogUtils.java
@@ -106,16 +106,7 @@ public class WebSubHubCorrelationLogUtils {
      */
     private static String createFormattedLog(List<String> logPropertiesList) {
 
-        StringBuilder sb = new StringBuilder();
-        int count = 0;
-        for (String property: logPropertiesList) {
-            sb.append(property);
-            if (count < logPropertiesList.size() - 1) {
-                sb.append(CORRELATION_LOG_SEPARATOR);
-            }
-            count++;
-        }
-        return sb.toString();
+        return String.join(CORRELATION_LOG_SEPARATOR, logPropertiesList);
     }
 
     /**


### PR DESCRIPTION
## Purpose

$subject 

## Goals

Improve outbound-connector by adding following changes.

- [x] Add correlation logs
  The correlation logs are currently not in the adapters. With thos improvement, we need transfer correlation logs to adapter.
- [x] Read timeout configurations from configuration file
  The timeout configurations are currently defined in the constants. We need to read the configurations from a properties file.
- [x] Throw exception when the adapter is disabled
Currently, the adapter doesn't throw an error when the adapter is disabled but publish/register topic/deregister topic methods is called. We need to throw an error to handle this.

