### PR TITLE
Handle WebSub hub topic deletion error response from the hub when there are active subscribers.

### DIFF
--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
@@ -27,13 +27,19 @@ public class WebSubHubAdapterConstants {
     public static final String AUDIENCE_BASE_URL = "https://websubhub/topics/";
     public static final String URL_SEPARATOR = "/";
     public static final String TOPIC_SEPARATOR = "-";
+    public static final String URL_PARAM_SEPARATOR = "&";
+    public static final String URL_KEY_VALUE_SEPARATOR = "=";
     public static final String PUBLISH = "publish";
     public static final String HUB_MODE = "hub.mode";
     public static final String HUB_TOPIC = "hub.topic";
+    public static final String HUB_REASON = "hub.reason";
+    public static final String HUB_ACTIVE_SUBS = "hub.active.subscribers";
     public static final String REGISTER = "register";
     public static final String DEREGISTER = "deregister";
     public static final String ACCEPTED = "accepted";
     public static final String RESPONSE_FOR_SUCCESSFUL_OPERATION = HUB_MODE + "=" + ACCEPTED;
+    public static final String ERROR_TOPIC_DEREG_FAILURE_ACTIVE_SUBS = "Topic %s could not be deregistered " +
+            "as there are active subscribers";
     public static final String CORRELATION_ID_REQUEST_HEADER = "activityid";
     public static final Integer DEFAULT_HTTP_CONNECTION_TIMEOUT = 300;
     public static final Integer DEFAULT_HTTP_READ_TIMEOUT = 300;
@@ -99,7 +105,9 @@ public class WebSubHubAdapterConstants {
         ERROR_CREATING_SSL_CONTEXT("65007", "Error while preparing SSL context for WebSubHub http client.",
                 "Server error encountered while preparing SSL context for WebSubHub http client."),
         ERROR_CREATING_ASYNC_HTTP_CLIENT("65008", "Error while creating the Async HTTP client.",
-                "Server error encountered while creating the Async HTTP Client of WebSub Hub Adapter.");
+                "Server error encountered while creating the Async HTTP Client of WebSub Hub Adapter."),
+        TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS("65016", "Error occurred while de-registering topic", "Backend error" +
+                " received from WebSubHub while attempting to de-register topic: %s. Active subscribers: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterConstants.java
@@ -106,7 +106,7 @@ public class WebSubHubAdapterConstants {
                 "Server error encountered while preparing SSL context for WebSubHub http client."),
         ERROR_CREATING_ASYNC_HTTP_CLIENT("65008", "Error while creating the Async HTTP client.",
                 "Server error encountered while creating the Async HTTP Client of WebSub Hub Adapter."),
-        TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS("65016", "Error occurred while de-registering topic", "Backend error" +
+        TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS("65009", "Error occurred while de-registering topic", "Backend error" +
                 " received from WebSubHub while attempting to de-register topic: %s. Active subscribers: %s.");
 
         private final String code;

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
@@ -61,6 +61,7 @@ import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.CORRELATION_ID_MDC;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.AUDIENCE_BASE_URL;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.CORRELATION_ID_REQUEST_HEADER;
+import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ERROR_TOPIC_DEREG_FAILURE_ACTIVE_SUBS;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.EVENT_ISSUER;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.ERROR_BACKEND_ERROR_FROM_WEBSUB_HUB;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB;
@@ -73,11 +74,16 @@ import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapter
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.ERROR_INVALID_WEB_SUB_OPERATION;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.ERROR_NULL_EVENT_PAYLOAD;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.ERROR_PUBLISHING_EVENT_INVALID_PAYLOAD;
+import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.ErrorMessages.TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS;
+import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.HUB_ACTIVE_SUBS;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.HUB_MODE;
+import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.HUB_REASON;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.HUB_TOPIC;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.PAYLOAD_EVENT_JSON_KEY;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.PUBLISH;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.RESPONSE_FOR_SUCCESSFUL_OPERATION;
+import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.URL_KEY_VALUE_SEPARATOR;
+import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.URL_PARAM_SEPARATOR;
 import static org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterConstants.URL_SEPARATOR;
 
 /**
@@ -285,6 +291,17 @@ public class WebSubHubAdapterUtil {
                         throw handleServerException(message, ERROR_EMPTY_RESPONSE_FROM_WEBSUB_HUB.getCode());
                     }
                 } else {
+                    if (response.getStatusLine().getStatusCode() == HttpStatus.SC_FORBIDDEN) {
+                        Map<String, String> hubResponse = parseEventHubResponse(response);
+                        if (!hubResponse.isEmpty() && hubResponse.containsKey(HUB_REASON)) {
+                            String errorMsg = String.format(ERROR_TOPIC_DEREG_FAILURE_ACTIVE_SUBS, topic);
+                            // If topic de-registration failed due to active subscriptions, throw a client exception.
+                            if (errorMsg.equals(hubResponse.get(HUB_REASON))) {
+                                throw handleClientException(TOPIC_DEREGISTRATION_FAILURE_ACTIVE_SUBS, topic,
+                                        hubResponse.get(HUB_ACTIVE_SUBS));
+                            }
+                        }
+                    }
                     HttpEntity entity = response.getEntity();
                     String responseString = "";
                     if (entity != null) {
@@ -381,4 +398,33 @@ public class WebSubHubAdapterUtil {
 
         return new WebSubAdapterServerException(message, errorCode);
     }
+
+    /**
+     * This method parses the urlencoded response from the event hub and returns the contents as a map.
+     * @param response Response from the event hub.
+     * @return Map of the response content.
+     * @throws IOException If an error occurs while parsing the response.
+     */
+    public static Map<String, String> parseEventHubResponse(CloseableHttpResponse response) throws IOException {
+
+        Map<String, String> map = new HashMap<>();
+        HttpEntity entity = response.getEntity();
+
+        if (entity != null) {
+            String responseContent = EntityUtils.toString(entity, StandardCharsets.UTF_8);
+            if (log.isDebugEnabled()) {
+                log.debug("Parsing response content from event hub: " + responseContent);
+            }
+            String[] responseParams = responseContent.split(URL_PARAM_SEPARATOR);
+            for (String param : responseParams) {
+                String[] keyValuePair = param.split(URL_KEY_VALUE_SEPARATOR);
+                // keyValuePair should contain key and value.
+                if (keyValuePair.length == 2) {
+                    map.put(keyValuePair[0], keyValuePair[1]);
+                }
+            }
+        }
+        return map;
+    }
+
 }

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
@@ -401,6 +401,7 @@ public class WebSubHubAdapterUtil {
 
     /**
      * This method parses the urlencoded response from the event hub and returns the contents as a map.
+     *
      * @param response Response from the event hub.
      * @return Map of the response content.
      * @throws IOException If an error occurs while parsing the response.


### PR DESCRIPTION
## Purpose
According to https://github.com/wso2-enterprise/azure-websubhub/pull/78, the hub returns an error response with the status code `403-Forbidden` and an appropriate response body when trying to delete a WebSub hub topic that has active subscriptions. This PR handles the aforementioned error response.
