### PR TITLE
Resolve request correlation log issues

### DIFF
--- a/components/org.wso2.identity.outbound.adapter.websubhub/pom.xml
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/pom.xml
@@ -130,6 +130,7 @@
                             com.nimbusds.jose.*; version="${nimbusds.osgi.version.range}",
                             org.wso2.carbon.identity.event; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.json.simple; version="${com.googlecode.json-simple.wso2.version.range}",
+                            org.slf4j; version="${org.slf4j.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
@@ -54,7 +54,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.apache.http.HttpHeaders.ACCEPT;
@@ -371,13 +370,18 @@ public class WebSubHubAdapterUtil {
 
     /**
      * Get correlation id from the MDC.
-     * If not then generate a random UUID and return the UUID.
+     * If not then generate a random UUID, add it to MDC and return the UUID.
      *
      * @return Correlation id
      */
     public static String getCorrelationID() {
-
-        return Optional.ofNullable(MDC.get(CORRELATION_ID_MDC)).orElse(UUID.randomUUID().toString());
+        
+        String correlationID = MDC.get(CORRELATION_ID_MDC);
+        if (StringUtils.isBlank(correlationID)) {
+            correlationID = UUID.randomUUID().toString();
+            MDC.put(CORRELATION_ID_MDC, correlationID);
+        }
+        return correlationID;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -319,5 +319,7 @@
 
         <testng.version>6.9.10</testng.version>
         <mockito.version>4.9.0</mockito.version>
+
+        <org.slf4j.imp.pkg.version.range>[1.5.5,2.0.0)</org.slf4j.imp.pkg.version.range>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
This PR contains fixes for the following issues identified as a part of https://github.com/wso2-enterprise/asgardeo-product/issues/16741

In the websubhub adapter component, correlation ID from MDC is always returned as null due to incorrect dependency -> Fixed by adding the correct dependency.

When correlation ID does not exist, it returns a randomly generated UUID, but it's not getting added to the MDC. As a result we can have request logs with no correlation ID -> Fixed by updating the MDC with generated UUID. 