### PR TITLE
JSON parsing removed as the response is not JSON encoded.

### DIFF
--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
@@ -209,25 +209,21 @@ public class WebSubHubAdapterUtil {
                 if (responseCode == 200 || responseCode == 201 || responseCode == 202 || responseCode == 204) {
                     // Check for 200 success code range.
                     if (log.isDebugEnabled()) {
-                        String jsonString;
+                        String responseBody;
                         try {
-                            jsonString = EntityUtils.toString(response.getEntity());
-                            JSONParser parser = new JSONParser();
-                            JSONObject json = (JSONObject) parser.parse(jsonString);
-                            log.debug("Response data: " + json);
-                        } catch (IOException | ParseException e) {
+                            responseBody = EntityUtils.toString(response.getEntity());
+                            log.debug("Response data: " + responseBody);
+                        } catch (IOException e) {
                             log.debug("Error while reading WebSubHub event publisher response. ", e);
                         }
                     }
                 } else {
                     log.error("WebHubSub event publisher received " + responseCode + " code.");
-                    String jsonString;
+                    String errorResponseBody;
                     try {
-                        jsonString = EntityUtils.toString(response.getEntity());
-                        JSONParser parser = new JSONParser();
-                        JSONObject json = (JSONObject) parser.parse(jsonString);
-                        log.error("Response data: " + json);
-                    } catch (IOException | ParseException e) {
+                        errorResponseBody = EntityUtils.toString(response.getEntity());
+                        log.error("Response data: " + errorResponseBody);
+                    } catch (IOException e) {
                         log.error("Error while reading WebSubHub event publisher response. ", e);
                     }
                 }


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to fix errors in logs in websubhub. The response sent from the hub is not json encoded which causes an error during parsing. This has been solved with this PR.

## Expected log output 

### Debug logs

TID: [] Tenant: [] [<date> <time>] [] : iam-cloud-carbon : DEBUG {org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterUtil} - Response data: hub.mode=<hub.mode>&hub.reason=<hub.reason>

### Error logs

TID: [] Tenant: [] [<date> <time>] [] : iam-cloud-carbon : ERROR {org.wso2.identity.outbound.adapter.websubhub.util.WebSubHubAdapterUtil} - Response data: hub.mode=<hub.mode>&hub.reason=<hub.reason>