### PR TITLE
Resolve response correlation log issues

### DIFF
--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
@@ -466,8 +466,7 @@ public class WebSubHubAdapterUtil {
 
         try {
             MDC.put(CORRELATION_ID_MDC, request.getFirstHeader(CORRELATION_ID_REQUEST_HEADER).getValue());
-            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(request, requestStartTime,
-                    otherParams);
+            WebSubHubCorrelationLogUtils.triggerCorrelationLogForResponse(request, requestStartTime, otherParams);
         } finally {
             MDC.remove(CORRELATION_ID_MDC);
         }

--- a/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
+++ b/components/org.wso2.identity.outbound.adapter.websubhub/src/main/java/org/wso2/identity/outbound/adapter/websubhub/util/WebSubHubAdapterUtil.java
@@ -240,7 +240,7 @@ public class WebSubHubAdapterUtil {
             @Override
             public void cancelled() {
 
-                handleResponseCorrelationLog(request, requestStartTime, RequestStatus.FAILED.getStatus());
+                handleResponseCorrelationLog(request, requestStartTime, RequestStatus.CANCELLED.getStatus());
                 log.error("Publishing event data to WebSubHub cancelled.");
             }
         });


### PR DESCRIPTION
## Purpose
This PR contains fixes for the following issue identified related to correlation logs in websubhub adapter.

- In the websubhub adapter component, no correlation ID included in the response correlation log.
